### PR TITLE
Fixed typographical error, changed accidentaly to accidentally in README.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -183,7 +183,7 @@ Kudos to LesBessant and fredl for reporting usage problems with Wordpress µ and
   * insert or edit current widgets in one click
   * handles all supported widgets for now
   * easy inclusion without having to read the documentation
- * widget: reintroduced the slideshow shortcode which was accidentaly removed
+ * widget: reintroduced the slideshow shortcode which was accidentally removed
 
 = Version 1.0 =
  * added Strict Standards compliance mode (`object` instead of `iframe`)


### PR DESCRIPTION
@oncletom, I've corrected a typographical error in the documentation of the [wp-amazon-widgets-shortcodes](https://github.com/oncletom/wp-amazon-widgets-shortcodes) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
